### PR TITLE
fix(ci): bump checkout to v7 and setup-python to v6 to clear Node 20 deprecation

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - name: Setup env and create distribution


### PR DESCRIPTION
## Problem

`publish-to-pypi.yml` pinned `actions/checkout@v4` and `actions/setup-python@v4`, both targeting Node.js 20. GitHub Actions runners are deprecating Node 20 and force-running these on Node 24, emitting a deprecation annotation on every run (observed on the `v0.1.3` publish run).

## Change

| Action | Before | After | Node runtime |
|---|---|---|---|
| `actions/checkout` | `@v4` | `@v7` | Node 24 |
| `actions/setup-python` | `@v4` | `@v6` | Node 24 |

## Deviation from #23

The issue asked to bump both to `@v5`. That would **not** clear the deprecation for `setup-python`: its `v5.x` line still runs on Node 20 — only `v6.0.0+` moved to Node 24. Pinned to the **current majors** of each action instead (checkout `v7`, setup-python `v6`), both of which run on Node 24. This also satisfies the issue's note to confirm the current major before pinning.

## Verification

- ✅ Pins are `checkout@v7` + `setup-python@v6`; YAML still parses.
- ⏳ Acceptance criterion "no Node 20 annotation" is only provable by CI on the next pushed `v*` tag — this workflow only runs on tag push, so it can't be exercised locally.

Low risk / no functional change — the workflow only checks out, sets up Python 3.12, and runs `make dist` + publish.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)